### PR TITLE
add item name quantity price status to merchant invoice show page

### DIFF
--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -6,3 +6,14 @@
   <p>Customer:</p>
   <p><%= @invoice.customer.first_name%> <%= @invoice.customer.last_name%></p>
 </div>
+<section>
+  <div id="items_on_this_invoice">
+    <h3> Items on this Invoice: </h3>
+    <% @invoice.invoice_items.each do |invoice_item| %>
+      <%=invoice_item.item.name %>
+      <%=invoice_item.quantity %>
+      <%=invoice_item.item.current_price %>
+      <%=invoice_item.status %>
+    <% end %>
+  </div>
+</section>

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'Invoice Show Page', type: :feature do
   let!(:invoice_item_7)  {InvoiceItem.create!(item_id: orion.id, invoice_id: invoice_11.id, quantity: 1, unit_price: 1000, status: "shipped")}
   let!(:invoice_item_8)  {InvoiceItem.create!(item_id: oil.id, invoice_id: invoice_11.id, quantity: 10, unit_price: 2599, status: "shipped")}
   let!(:invoice_item_9)  {InvoiceItem.create!(item_id: pants.id, invoice_id: invoice_2.id, quantity: 1, unit_price: 2100, status: "shipped")}
+  
 
   let!(:stickers) {nomi.items.create!(name: "Anime Stickers", description: "Random One Piece and Death Note stickers", unit_price: 599)}
   let!(:lamp) {nomi.items.create!(name: "Lava Lamp", description: "Special blue/purple wax inside a glass vessel", unit_price: 2000)}
@@ -52,5 +53,19 @@ RSpec.describe 'Invoice Show Page', type: :feature do
         expect(page).to have_content("#{luffy.first_name} #{luffy.last_name}")
       end
     end
+
+      it 'I see all of my items on the invoice' do
+        visit  merchant_invoice_path(nomi, invoice_1)
+
+        expect(page).to have_content("Items on this Invoice:")
+        within ("#items_on_this_invoice") do
+          expect(page).to have_content("#{invoice_item_1.item.name}")
+          expect(page).to have_content("#{invoice_item_1.quantity}")
+          expect(page).to have_content("#{invoice_item_1.item.current_price}")
+          expect(page).to have_content("#{invoice_item_1.status}")
+          expect(page).to_not have_content("#{invoice_item_8.item.name}")
+          expect(page).to_not have_content("#{invoice_item_9.item.name}")
+        end
+      end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Merchant, type: :model do
       expect(nomi.customers.top_five_customers[2].id).to eq(sue.id)
       expect(nomi.customers.top_five_customers[3].id).to eq(louise.id)
       expect(nomi.customers.top_five_customers[4].id).to eq(alfred.id)
+      
     end
   end
 


### PR DESCRIPTION
added item name, quantity, status, unit price on merchant invoice show page. This does not have styling done it to, like in the wire frame, but returns the correct information for this user story.