### PR TITLE
fix api calls to not include collaborators and the authentication token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,8 @@
 class ApplicationController < ActionController::Base
-  before_action :repo_name
+  before_action :github_info
 
-  def repo_name
+  def github_info
     @repo = GithubSearch.repo_name
-    @collabs = GithubSearch.collab_info
     @commits = GithubSearch.commits
     @pulls = GithubSearch.pulls
   end

--- a/app/poros/collaborator.rb
+++ b/app/poros/collaborator.rb
@@ -1,7 +1,0 @@
-class Collaborator
-  attr_reader :login
-
-  def initialize(data)
-    @login = data[:login]
-  end
-end

--- a/app/poros/contributor.rb
+++ b/app/poros/contributor.rb
@@ -1,8 +1,8 @@
 class Contributor
-
-  attr_reader :commits
+  attr_reader :commits, :login
 
   def initialize(data)
     @commits = data[:contributions]
+    @login = data[:login]
   end
 end

--- a/app/poros/github_search.rb
+++ b/app/poros/github_search.rb
@@ -1,21 +1,12 @@
 require 'httparty'
 require 'pry'
 require './app/poros/repo_name'
-require './app/poros/collaborator'
 require './app/services/github_service'
 require './app/poros/contributor'
-
-
 
 class GithubSearch
   def self.repo_name
     GithubService.repo_name
-  end
-
-  def self.collab_info
-    GithubService.collaborators.map do |collab|
-      Collaborator.new(collab)
-    end
   end
 
   def self.commits

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -4,10 +4,6 @@ class GithubService
   def self.repo_name
     get_uri("https://api.github.com/repos/naomiyocum/little-esty-shop")
   end
-
-  def self.collaborators
-    get_uri("https://api.github.com/repos/naomiyocum/little-esty-shop/collaborators")
-  end
   
   def self.contributors
     get_uri("https://api.github.com/repos/naomiyocum/little-esty-shop/contributors")
@@ -18,7 +14,7 @@ class GithubService
   end
 
   def self.get_uri(uri)
-    response = HTTParty.get(uri, headers: {"Authorization" => "Bearer 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"})
+    response = HTTParty.get(uri)
     JSON.parse(response.body, symbolize_names: true)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,11 +21,8 @@
     <%= yield %>
   </body>
   <footer>
-   <%= @repo[:name] %>
-   <% @collabs.each do |collab| %>
-    <%= collab.login %>
-   <% end %>
+   <ul><%= @repo[:name] %></ul>
+   <ul>The contributors to this project include <%= @commits.map {|user| user.login}.to_sentence %></ul>
    <ul>Commits:<%= @commits.sum {|user| user.commits}%> Pull Requests:<%= @pulls.first.number %></ul>
-   
   </footer>
 </html>


### PR DESCRIPTION
I got rid of all of our methods that was used for the `https://api.github.com/repos/naomiyocum/little-esty-shop/collaborators` so now we do not need an authentication token. Added login to our contributor class so we could access it that way.